### PR TITLE
Update nm-create.ps1

### DIFF
--- a/nm-config.ps1
+++ b/nm-config.ps1
@@ -1,5 +1,6 @@
 
 param (
+    [bool] $DynamicDisk,
     [Int32] $DefaultDiskSize= 1GB,
     [Parameter(Mandatory = $true)]
     [string] $DisksFolder
@@ -7,4 +8,4 @@ param (
 
 . "$PSScriptRoot\nm-functions.ps1"
 
-Write-Config -DefaultDiskSize $DefaultDiskSize -DisksFolder $DisksFolder
+Write-Config -DefaultDiskSize $DefaultDiskSize -DisksFolder $DisksFolder -DynamicDisk $DynamicDisk

--- a/nm-create.ps1
+++ b/nm-create.ps1
@@ -30,7 +30,7 @@ if(Test-Path $vhdpath)
     }
 }
 
-$partition = New-VHD -Path $vhdpath -Fixed -SizeBytes $vhdsize |
+$partition = New-VHD -Path $vhdpath -SizeBytes $vhdsize |
 Mount-VHD -NoDriveLetter -Passthru |
 Initialize-Disk -Passthru |
 New-Partition -UseMaximumSize 

--- a/nm-functions.ps1
+++ b/nm-functions.ps1
@@ -62,6 +62,7 @@ function Get-Startup-Script {
 
 function Write-Config {
     param (
+        [bool] $DynamicDisk,
         [Int32] $DefaultDiskSize= 1GB,
         [Parameter(Mandatory = $true)]
         [string] $DisksFolder
@@ -72,6 +73,7 @@ function Write-Config {
     $settings = @{}
     $settings.DefaultDiskSize = $DefaultDiskSize
     $settings.DisksFolder = $DisksFolder
+    $settings.DynamicDisk = $DynamicDisk
 
     ConvertTo-Json -InputObject $settings | Out-File $settingsPath
 }


### PR DESCRIPTION
Removed the "-Fixed" flag from the call to "New-VHD" - the result is a virtual drive that will present itself as having the default size, but will only take up the needed amount of space on disk (usually much much less).