### PR TITLE
If nm-create is run with PS6, re-run with lower version

### DIFF
--- a/nm-create.ps1
+++ b/nm-create.ps1
@@ -1,4 +1,3 @@
-
 param (
     [string] $folder,
     [Int] $DiskSize,
@@ -6,6 +5,13 @@ param (
 )
     
 $ErrorActionPreference = "Stop"
+
+# powershell 6 does not support New-JobTrigger
+if ($PSVersionTable.PSVersion.Major -gt 5)
+{
+    powershell -File "$($MyInvocation.MyCommand.Definition)"
+    exit $LASTEXITCODE
+}
 
 . "$PSScriptRoot\nm-functions.ps1"
 


### PR DESCRIPTION
PS6 does not currently have support for `New-JobTrigger` and all of that, so if you run the script with `pwsh` you end up with broken links next time you restart the machine. This is a small hack to run with the correct version (oh how we could use a windows shebang :confused: ...